### PR TITLE
[fw] fluffyctl option to reinitiate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ craftsmanship.*
 
 # Fluffy - A 'free' watchdog for Linux on-disk filesystems [WIP]
 
-__Fluffy__ is a convenient front-end tool, __libfluffy__ is what you 
+__Fluffy__ is a convenient CLI tool, __libfluffy__ is what you 
 will find under the hood. libfluffy uses the inotify kernel subsystem.
 
 There are challenges in using the native [inotify][] library 
@@ -178,6 +178,7 @@ Application Options:
   -I, --ignore=/knockturn/alley/borgin/brukes     Paths to ignore recursively. Repeat flag for multiple paths.
   -W, --max-user-watches=524288                   Upper limit on the number of watches per uid [fluffy defaults 524288]
   -Q, --max-queued-events=524288                  Upper limit on the number of events [fluffy defaults 524288]
+  -z, --reinit                                    Reinitiate watch on all root paths. [Avoid unless necessary]
 
 ```
 
@@ -225,9 +226,10 @@ path:   /tmp/sh-thd-1809946088
 
 There's still quite a few more to be done but these are the primary ones
 
- - Fluffy frontend _WIP_
  - Documentation _WIP_
- - Proper error reporting
+ - Fluffy frontend _WIP_
+ - Proper error reporting. For now, most error returns have been set -1 
+   deliberately without any error string or value.
  - Valgrind
  - Test cases
  - Doxygen?

--- a/libfluffy/fluffy.c
+++ b/libfluffy/fluffy.c
@@ -1970,14 +1970,12 @@ fluffy_print_event(const struct fluffy_event_info *eventinfo,
 	fprintf(stdout, "\n");
 	fprintf(stdout, "path:\t%s\n", eventinfo->path ? eventinfo->path : "");
 
-	/*
 	if (eventinfo->event_mask & FLUFFY_WATCH_EMPTY) {
 		int m = 0;
 		int fluffy_handle = *(int *)user_data;
 		m = fluffy_destroy(fluffy_handle);
 		return m;
 	}
-	*/
 
 	return 0;
 }

--- a/src/fluffy_impl.c
+++ b/src/fluffy_impl.c
@@ -4,8 +4,9 @@ const char mqfluffy[] = "/mqfluffy";	/* Message queue name */
 const char id_mqfluffy_exit = 'x';
 const char id_mqfluffy_watch = 'w';
 const char id_mqfluffy_ignore = 'I';
-const char id_mqfluffy_max_user_watches = 'W';
+const char id_mqfluffy_max_user_watches = 'U';
 const char id_mqfluffy_max_queued_events = 'Q';
+const char id_mqfluffy_reinitiate = 'z';
 const char id_mqfluffy_list_root_path = 'l';
 const char id_mqfluffy_events_mask = 'E';
 

--- a/src/fluffy_impl.h
+++ b/src/fluffy_impl.h
@@ -27,6 +27,7 @@ extern const char mqfluffy[];
 extern const char id_mqfluffy_exit;
 extern const char id_mqfluffy_watch;
 extern const char id_mqfluffy_ignore;
+extern const char id_mqfluffy_reinitiate;
 extern const char id_mqfluffy_list_root_path;
 extern const char id_mqfluffy_max_user_watches;
 extern const char id_mqfluffy_max_queued_events;

--- a/src/fluffy_run.c
+++ b/src/fluffy_run.c
@@ -216,6 +216,14 @@ process_fluffy_mqueue(struct epoll_event *evlist)
 			}
 		}
 
+		if (mqmsg[0] == id_mqfluffy_reinitiate) {
+			reterr = reinitiate_run();
+			if (reterr) {
+				free(mqmsg);
+				return reterr;
+			}
+		}
+
 		if (mqmsg[0] == id_mqfluffy_list_root_path) {
 			free(mqmsg);
 			return 0;
@@ -367,6 +375,15 @@ terminate_run()
 	}
 }
 
+int
+reinitiate_run()
+{
+	if (fluffy_reinitiate_context(flh)) {
+		return -1;
+	}
+
+	return 0;
+}
 
 int
 main(int argc, char *argv[])


### PR DESCRIPTION
Fluffy doesn't miss any action on the fs, nevertheless, a user might
want to reinitate the watch. Is this option required? Can't Fluffy be
stopped and restarted to have the same effect? Well, yes, but the
watches will then have to be set manually. A reinitate call handles it.
And, retains the events choice and other previously set limits as well.

Signed-off-by: Raamsri KP <raam@tinkershack.in>