### PR TITLE
[fw] Options to support file path globbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,10 @@ Application Options:
   -O, --outfile=./out.fluffy                      File to print output [default:stdout]
   -E, --errfile=./err.fluffy                      File to print errors [default:stderr]
   -w, --watch=/grimmauld/place/12                 Paths to watch recursively. Repeat flag for multiple paths.
-  -I, --ignore=/knockturn/alley/borgin/brukes     Paths to ignore recursively. Repeat flag for multiple paths.
-  -W, --max-user-watches=524288                   Upper limit on the number of watches per uid [fluffy defaults 524288]
+  -W, --watch-glob                                Paths to watch recursively: supports wildcards. Any non-option argument passed will be considered as paths. [/hogwarts/*/towers]
+  -i, --ignore=/knockturn/alley/borgin/brukes     Paths to ignore recursively. Repeat flag for multiple paths.
+  -I, --ignore-glob                               Paths to ignore recursively: supports wildcards. Any non-option argument passed will be considered as paths. [/hogwarts/*/dungeons]
+  -U, --max-user-watches=524288                   Upper limit on the number of watches per uid [fluffy defaults 524288]
   -Q, --max-queued-events=524288                  Upper limit on the number of events [fluffy defaults 524288]
   -z, --reinit                                    Reinitiate watch on all root paths. [Avoid unless necessary]
 

--- a/src/fluffy_impl.c
+++ b/src/fluffy_impl.c
@@ -3,7 +3,7 @@
 const char mqfluffy[] = "/mqfluffy";	/* Message queue name */
 const char id_mqfluffy_exit = 'x';
 const char id_mqfluffy_watch = 'w';
-const char id_mqfluffy_ignore = 'I';
+const char id_mqfluffy_ignore = 'i';
 const char id_mqfluffy_max_user_watches = 'U';
 const char id_mqfluffy_max_queued_events = 'Q';
 const char id_mqfluffy_reinitiate = 'z';

--- a/src/fluffy_run.c
+++ b/src/fluffy_run.c
@@ -390,8 +390,8 @@ main(int argc, char *argv[])
 {
 	gchar option_context[] = "[exit]";
 	gchar context_description[] = "Please report bugs at " \
-				     "https://github.com/six-k/fluffy or " \
-				     "raam@tinkershack.in\n";
+				     "https://github.com/tinkershack/fluffy "\
+				     "or raam@tinkershack.in\n";
 	gchar *print_out = NULL;
 	gchar *print_err = NULL;
 	GOptionEntry entries_g[]= {


### PR DESCRIPTION
Two new options -W and -I to handle arguments with wildcards.

Users wish to use wildcards for paths. We must get the arguments with
the wildcards and glob it. But for now, let's leave it to the shell to
handle it for us. We will extract the globbed paths from *argv[].

Signed-off-by: Raamsri KP <raam@tinkershack.in>