### PR TITLE
[fw] Make the event logs simple to parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,42 +187,75 @@ Application Options:
 #### fluffy event log snippet
 
 ```
-event:  CLOSE_NOWRITE, ISDIR, 
-path:   /tmp/.Test-unix
-
-event:  ACCESS, ISDIR, 
-path:   /tmp/systemd-private-6f74e3b317d0471b8546d2a83261b721-cups.service-3wkDKu
-
-event:  ACCESS, ISDIR, 
-path:   /tmp/systemd-private-6f74e3b317d0471b8546d2a83261b721-cups.service-3wkDKu/tmp
-
-event:  MODIFY, 
-path:   /var/log/messages
-
-event:  MODIFY, 
-path:   /var/log/syslog
-
-event:  OPEN, ISDIR, 
-path:   /var/log
-
-event:  ACCESS, ISDIR, 
-path:   /var/log
-
-event:  CLOSE_NOWRITE, ISDIR, 
-path:   /var/log
-
-event:  OPEN, ISDIR, 
-path:   /var/log
-
-event:  ACCESS, ISDIR, 
-path:   /var/log
-
-event:  CLOSE_NOWRITE, ISDIR, 
-path:   /var/log
-
-event:  CREATE, 
-path:   /tmp/sh-thd-1809946088
+MODIFY, /var/log/daemon.log
+MODIFY, /var/log/syslog
+MODIFY, /var/log/kern.log
+MODIFY, /var/log/messages
+GNORED, /var/log/apache2
+IGNORED,        /var/log/tor
+IGNORED,        /var/log/vmware
+CREATE,ISDIR,   /tmp/test
+ACCESS,ISDIR,   /tmp/test
+ACCESS,ISDIR,   /tmp/test
+CLOSE_NOWRITE,ISDIR,    /tmp/test
+CREATE, /tmp/test/f1
+OPEN,   /tmp/test/f1
+ATTRIB, /tmp/test/f1
+CLOSE_WRITE,    /tmp/test/f1
+OPEN,   /tmp/test/f1
+MODIFY, /tmp/test/f1
+MODIFY, /tmp/test/f1
+MODIFY, /tmp/test/f1
+CLOSE_WRITE,    /tmp/test/f1
+IGNORED,ROOT_IGNORED,WATCH_EMPTY,       /tmp
 ```
+
+
+#### Perform actions on events from CLI
+
+**CAUTION** It's is recommended that you use `libfluffy` to perform 
+actions on events. 
+
+Let's consider a trivial action: `ls -l` the path on a MODIFY event
+
+At terminal:1
+
+```
+root@six-k:/home/lab/fluffy# fluffy | \
+while read events path; do \
+    if echo $events | grep -qie "MODIFY"; then \
+        ls -l $path; \
+    fi \
+done
+```
+
+At terminal:2
+
+```
+root@six-k:/opt/test2# fluffyctl -w ./
+root@six-k:/opt/test2# touch f1
+root@six-k:/opt/test2# ls -l
+total 0
+-rw-r--r-- 1 root root 0 Mar 18 19:38 f1
+root@six-k:/opt/test2# echo "this is a MODIFY" | cat >> f1
+root@six-k:/opt/test2# echo "this is another MODIFY" | cat >> f1
+root@six-k:/opt/test2# fluffy exit
+```
+
+Output from terminal:1: [cont.]
+
+```
+root@six-k:/home/lab/fluffy# fluffy | \
+> while read events path; do \
+>     if echo $events | grep -qie "MODIFY"; then \
+>         ls -l $path; \
+>     fi \
+> done
+-rw-r--r-- 1 root root 17 Mar 18 19:38 /opt/test2/f1
+-rw-r--r-- 1 root root 40 Mar 18 19:38 /opt/test2/f1
+root@six-k:/home/lab/fluffy# 
+```
+
 
 ### TODO: Fluffy is a WIP
 

--- a/src/fluffy_run.c
+++ b/src/fluffy_run.c
@@ -35,6 +35,7 @@ void terminate_run();
 int process_fluffy_mqueue(struct epoll_event *evlist);
 int print_events(const struct fluffy_event_info *eventinfo, void *user_data);
 int set_print_events_mask(char *mask);
+int reinitiate_run();
 
 /* Function definitions */
 
@@ -63,65 +64,64 @@ print_events(const struct fluffy_event_info *eventinfo,
 		return 0;
 	}
 
-	fprintf(stdout, "\n");
-	fprintf(stdout, "event:\t");
+	PRINT_STDOUT("\n", "");
 	if (eventinfo->event_mask & FLUFFY_ACCESS &&
 	    print_events_mask & FLUFFY_ACCESS)
-		fprintf(stdout, "ACCESS, ");
+		PRINT_STDOUT("ACCESS,", "");
 	if (eventinfo->event_mask & FLUFFY_ATTRIB &&
 	    print_events_mask & FLUFFY_ATTRIB)
-		fprintf(stdout, "ATTRIB, ");
+		PRINT_STDOUT("ATTRIB,", "");
 	if (eventinfo->event_mask & FLUFFY_CLOSE_NOWRITE &&
 	    print_events_mask & FLUFFY_CLOSE_NOWRITE)
-		fprintf(stdout, "CLOSE_NOWRITE, ");
+		PRINT_STDOUT("CLOSE_NOWRITE,", "");
 	if (eventinfo->event_mask & FLUFFY_CLOSE_WRITE &&
 	    print_events_mask & FLUFFY_CLOSE_WRITE)
-		fprintf(stdout, "CLOSE_WRITE, ");
+		PRINT_STDOUT("CLOSE_WRITE,", "");
 	if (eventinfo->event_mask & FLUFFY_CREATE &&
 	    print_events_mask & FLUFFY_CREATE)
-		fprintf(stdout, "CREATE, ");
+		PRINT_STDOUT("CREATE,", "");
 	if (eventinfo->event_mask & FLUFFY_DELETE &&
 	    print_events_mask & FLUFFY_DELETE)
-		fprintf(stdout, "DELETE, ");
+		PRINT_STDOUT("DELETE,", "");
 	if (eventinfo->event_mask & FLUFFY_ROOT_DELETE &&
 	    print_events_mask & FLUFFY_ROOT_DELETE)
-		fprintf(stdout, "ROOT_DELETE, ");
+		PRINT_STDOUT("ROOT_DELETE,", "");
 	if (eventinfo->event_mask & FLUFFY_MODIFY &&
 	    print_events_mask & FLUFFY_MODIFY)
-		fprintf(stdout, "MODIFY, ");
+		PRINT_STDOUT("MODIFY,", "");
 	if (eventinfo->event_mask & FLUFFY_ROOT_MOVE &&
 	    print_events_mask & FLUFFY_ROOT_MOVE)
-		fprintf(stdout, "ROOT_MOVE, ");
+		PRINT_STDOUT("ROOT_MOVE,", "");
 	if (eventinfo->event_mask & FLUFFY_MOVED_FROM &&
 	    print_events_mask & FLUFFY_MOVED_FROM)
-		fprintf(stdout, "MOVED_FROM, ");
+		PRINT_STDOUT("MOVED_FROM,", "");
 	if (eventinfo->event_mask & FLUFFY_MOVED_TO &&
 	    print_events_mask & FLUFFY_MOVED_TO)
-		fprintf(stdout, "MOVED_TO, ");
+		PRINT_STDOUT("MOVED_TO,", "");
 	if (eventinfo->event_mask & FLUFFY_OPEN &&
 	    print_events_mask & FLUFFY_OPEN)
-		fprintf(stdout, "OPEN, ");
+		PRINT_STDOUT("OPEN,", "");
 
 	if (eventinfo->event_mask & FLUFFY_IGNORED &&
 	    print_events_mask & FLUFFY_IGNORED)
-		fprintf(stdout, "IGNORED, ");
+		PRINT_STDOUT("IGNORED,", "");
 	if (eventinfo->event_mask & FLUFFY_ISDIR &&
 	    print_events_mask & FLUFFY_ISDIR)
-		fprintf(stdout, "ISDIR, ");
+		PRINT_STDOUT("ISDIR,", "");
 	if (eventinfo->event_mask & FLUFFY_UNMOUNT &&
 	    print_events_mask & FLUFFY_UNMOUNT)
-		fprintf(stdout, "UNMOUNT, ");
+		PRINT_STDOUT("UNMOUNT,", "");
 	if (eventinfo->event_mask & FLUFFY_ROOT_IGNORED &&
 	    print_events_mask & FLUFFY_ROOT_IGNORED)
-		fprintf(stdout, "ROOT_IGNORED, ");
+		PRINT_STDOUT("ROOT_IGNORED,", "");
 	if (eventinfo->event_mask & FLUFFY_WATCH_EMPTY &&
 	    print_events_mask & FLUFFY_WATCH_EMPTY)
-		fprintf(stdout, "WATCH_EMPTY, ");
+		PRINT_STDOUT("WATCH_EMPTY,", "");
 	if (eventinfo->event_mask & FLUFFY_Q_OVERFLOW &&
 	    print_events_mask & FLUFFY_Q_OVERFLOW)
-		fprintf(stdout, "Q_OVERFLOW, ");
-	fprintf(stdout, "\n");
-	fprintf(stdout, "path:\t%s\n", eventinfo->path ? eventinfo->path : "");
+		PRINT_STDOUT("Q_OVERFLOW,", "");
+	PRINT_STDOUT("\t", "");
+	PRINT_STDOUT("%s", eventinfo->path ? eventinfo->path : "", "");
 
 	/*
 	if (eventinfo->event_mask & FLUFFY_WATCH_EMPTY) {


### PR DESCRIPTION
Printing events and its path on separate lines may not be quite easy for
users to parse should they prefer to act on events from the CLI itself.

Fix it by printing comma separated event actions followed by a tabspace
and then the event path.

Example:
CREATE,ISDIR,	/tmp/test

Signed-off-by: Raamsri KP <raam@tinkershack.in>