### PR TITLE
Update fluffy_print_event helper function

### DIFF
--- a/libfluffy/example.c
+++ b/libfluffy/example.c
@@ -10,65 +10,60 @@ int
 main(int argc, char *argv[])
 {
 	int ret = 0;
-	int fh1 = 0;
+	int flhandle = 0;       /* Fluffy handle */
+	int rc = EXIT_SUCCESS;	/* Return code */
 
-	if (argc < 3) {
-		fprintf(stderr, "Atleast two paths required.\n");
+	if (argc < 2) {
+		fprintf(stderr, "Atleast a path required.\n");
 		exit(EXIT_FAILURE);
 	}
 
-	ret = fluffy_set_max_user_instances("4096");
-	if (ret != 0) {
-		fprintf(stderr, "fluffy_set_max_user_instances fail\n");
-	}
-	fprintf(stdout, "fluffy_set_max_user_instances done\n");
-
+        /* /proc/sys/fs/inotify/max_user_watches */
 	ret = fluffy_set_max_user_watches("524288");
 	if (ret != 0) {
 		fprintf(stderr, "fluffy_set_max_user_watches fail\n");
 	}
-	fprintf(stdout, "fluffy_set_max_user_watches done\n");
 
+        /* /proc/sys/fs/inotify/max_queued_events */
 	ret = fluffy_set_max_queued_events("524288");
 	if (ret != 0) {
 		fprintf(stderr, "fluffy_set_max_queued_events fail\n");
 	}
-	fprintf(stdout, "fluffy_set_max_queued_events done\n");
 
-
-	fh1 = fluffy_init(fluffy_print_event, (void *)&fh1);
-	if (fh1 < 1) {
-		fprintf(stderr, "fluffy_init fh1 fail\n");
+        /*
+	 * Initiate fluffy and print events on the standard out with the help
+	 * of libfluffy's print event helper function.
+	 *
+	 * Look at fluffy.h for help with plugfing your custom event handler
+	 */
+	flhandle = fluffy_init(fluffy_print_event, (void *)&flhandle);
+	if (flhandle < 1) {
+		fprintf(stderr, "fluffy_init fail\n");
 		exit(EXIT_FAILURE);
 	}
-	fprintf(stdout, "fluffy_init fh1 done\n");
 
-	ret = fluffy_add_watch_path(fh1, argv[1]);
-	if (ret != 0) {
-		fprintf(stderr, "fluffy_add_watch_path fh1:%s fail\n", argv[1]);
+	do {
+		/* Watch argv[1] */
+		ret = fluffy_add_watch_path(flhandle, argv[1]);
+		if (ret != 0) {
+			fprintf(stderr, "fluffy_add_watch_path %s fail\n",
+					argv[1]);
+			rc = EXIT_FAILURE;
+			break;
+		}
+
+		/* Let us not exit until Fluffy exits/returns */
+		ret = fluffy_wait_until_done(flhandle);
+		if (ret != 0) {
+			fprintf(stderr, "fluffy_wait_until_done fail\n");
+			rc = EXIT_FAILURE;
+			break;
+		}
+	} while(0);
+
+	if (rc != EXIT_SUCCESS) {
+		ret = fluffy_destroy(flhandle);	/* Destroy Fluffy context */
 	}
-	fprintf(stdout, "fluffy_add_watch_path 1 done\n");
 
-	ret = fluffy_add_watch_path(fh1, argv[2]);
-	if (ret != 0) {
-		fprintf(stderr, "fluffy_add_watch_path fh1:%s fail\n", argv[2]);
-	}
-	fprintf(stdout, "fluffy_add_watch_path 2 done\n");
-
-	sleep(30);
-
-	ret = fluffy_reinitiate_all_contexts();
-	if (ret != 0) {
-		fprintf(stderr, "fluffy_reinitiate_all_contexts fail\n");
-	}
-	fprintf(stdout, "fluffy_reinitiate_all_contexts done\n");
-
-	ret = fluffy_wait_until_done(fh1);
-	if (ret != 0) {
-		fprintf(stderr, "fluffy_wait_until_done fh1 fail\n");
-		exit(EXIT_FAILURE);
-	}
-	fprintf(stdout, "fluffy_wait_until_done ok\n");
-
-	exit(EXIT_SUCCESS);
+	exit(rc);
 }

--- a/libfluffy/fluffy.c
+++ b/libfluffy/fluffy.c
@@ -2301,8 +2301,6 @@ int
 fluffy_print_event(const struct fluffy_event_info *eventinfo,
     void *user_data)
 {
-	fprintf(stdout, "\n");
-	fprintf(stdout, "event:\t");
 	if (eventinfo->event_mask & FLUFFY_ACCESS)
 		fprintf(stdout, "ACCESS, ");
 	if (eventinfo->event_mask & FLUFFY_ATTRIB)
@@ -2339,8 +2337,8 @@ fluffy_print_event(const struct fluffy_event_info *eventinfo,
 		fprintf(stdout, "ROOT_IGNORED, ");
 	if (eventinfo->event_mask & FLUFFY_WATCH_EMPTY)
 		fprintf(stdout, "WATCH_EMPTY, ");
-	fprintf(stdout, "\n");
-	fprintf(stdout, "path:\t%s\n", eventinfo->path ? eventinfo->path : "");
+	fprintf(stdout, "\t");
+	fprintf(stdout, "%s\n", eventinfo->path ? eventinfo->path : "");
 
 	if (eventinfo->event_mask & FLUFFY_WATCH_EMPTY) {
 		int m = 0;

--- a/libfluffy/fluffy.h
+++ b/libfluffy/fluffy.h
@@ -273,9 +273,10 @@ extern int fluffy_set_max_user_watches(const char *max_size);
  * Function:	fluffy_print_event
  *
  * A helper function to print the event path and event action to the standard
- * output. This function must be passed as an argument to the fluffy_init()
+ * output. This function must be passed as an argument only to the fluffy_init()
  * call, not to be called separately. Fluffy calls the print function on every
- * event as long as the watch list is not empty.
+ * event as long as the watch list is not empty. Fluffy context is destroyed
+ * when the watch list becomes empty.
  *
  * args:
  * 	- const struct fluffy_event_info *:	This will be provided by fluffy.

--- a/src/fluffy_run.c
+++ b/src/fluffy_run.c
@@ -64,7 +64,6 @@ print_events(const struct fluffy_event_info *eventinfo,
 		return 0;
 	}
 
-	PRINT_STDOUT("\n", "");
 	if (eventinfo->event_mask & FLUFFY_ACCESS &&
 	    print_events_mask & FLUFFY_ACCESS)
 		PRINT_STDOUT("ACCESS,", "");
@@ -121,7 +120,7 @@ print_events(const struct fluffy_event_info *eventinfo,
 	    print_events_mask & FLUFFY_Q_OVERFLOW)
 		PRINT_STDOUT("Q_OVERFLOW,", "");
 	PRINT_STDOUT("\t", "");
-	PRINT_STDOUT("%s", eventinfo->path ? eventinfo->path : "", "");
+	PRINT_STDOUT("%s\n", eventinfo->path ? eventinfo->path : "", "");
 
 	/*
 	if (eventinfo->event_mask & FLUFFY_WATCH_EMPTY) {


### PR DESCRIPTION
Print events and its associated path on the same line separated by a tab
space while the events are separated by commas.

Signed-off-by: Raamsri KP <raam@tinkershack.in>