### PR TITLE
 Ignore events captured on the output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ function calls available.
 
 __Primary functions__
 
-```
+```c
 int fluffy_init(int (*user_event_fn) (
     const struct fluffy_event_info *eventinfo,
     void *user_data), void *user_data);
@@ -118,7 +118,7 @@ int fluffy_destroy(int fluffy_handle);
 
 __Helper functions__
 
-```
+```c
 int fluffy_print_event(const struct fluffy_event_info *eventinfo,
     void *user_data);
 
@@ -135,7 +135,7 @@ int fluffy_set_max_user_watches(const char *max_size);
 
 #### [A simple example program using `libfluffy`](#contents)
 
-```
+```c
 /*
  * example.c
  */
@@ -243,7 +243,7 @@ folder](https://stackoverflow.com/questions/47225008/how-to-use-inotifywait-to-w
 
 ### [Don't mind getting your hands dirty?](#contents)
 
-```
+```bash
 # Fork and clone this repo
 # Ensure glib-2.0 has been installed
 # cd to fluffy dir
@@ -299,7 +299,7 @@ make example
 
 #### fluffy usage
 
-```
+```bash
 root@six-k:~# fluffy -h
 Usage:
   fluffy [OPTION...] [exit]
@@ -315,7 +315,7 @@ Application Options:
 
 #### fluffyctl usage
 
-```
+```bash
 root@six-k:~# fluffyctl --help-all
 Usage:
   fluffyctl [OPTION...] ["/path/to/hogwarts/kitchen"]
@@ -355,8 +355,6 @@ option, previously set events choice is discarded; overrides.
   --watch-empty                                   Watch whether all Fluffy watches are removed ['isdir' not raised]
 
 Application Options:
-  -O, --outfile=./out.fluffy                      File to print output [default:stdout]
-  -E, --errfile=./err.fluffy                      File to print errors [default:stderr]
   -w, --watch=/grimmauld/place/12                 Paths to watch recursively. Repeat flag for multiple paths.
   -W, --watch-glob                                Paths to watch recursively: supports wildcards. Any non-option argument passed will be considered as paths. [/hogwarts/*/towers]
   -i, --ignore=/knockturn/alley/borgin/brukes     Paths to ignore recursively. Repeat flag for multiple paths.
@@ -369,7 +367,7 @@ Application Options:
 
 #### Fluffy event log snippet
 
-```
+```bash
 MODIFY, /var/log/daemon.log
 MODIFY, /var/log/syslog
 MODIFY, /var/log/kern.log
@@ -396,14 +394,14 @@ IGNORED,ROOT_IGNORED,WATCH_EMPTY,       /tmp
 
 #### Perform actions on events from CLI
 
-**CAUTION** It's is recommended that you use `libfluffy` to perform 
-actions on events. 
+**CAUTION** It's recommended that you use `libfluffy` to perform 
+sophisticated actions on events rather than scripting with CLI usage. 
 
 Let's consider a trivial action: `ls -l` the path on a MODIFY event
 
 At terminal:1
 
-```
+```bash
 root@six-k:/home/lab/fluffy# fluffy | \
 while read events path; do \
     if echo $events | grep -qie "MODIFY"; then \
@@ -414,7 +412,7 @@ done
 
 At terminal:2
 
-```
+```bash
 root@six-k:/opt/test2# fluffyctl -w ./
 root@six-k:/opt/test2# touch f1
 root@six-k:/opt/test2# ls -l
@@ -427,7 +425,7 @@ root@six-k:/opt/test2# fluffy exit
 
 Output from terminal:1: [cont.]
 
-```
+```bash
 root@six-k:/home/lab/fluffy# fluffy | \
 > while read events path; do \
 >     if echo $events | grep -qie "MODIFY"; then \
@@ -449,16 +447,13 @@ There's still quite a few more to be done but these are the primary ones
    deliberately without any error string or value.
  - Valgrind
  - Test cases
- - Doxygen?
 
- - Fix makefiles, it's poorly formed.
  - Other helper functions
    - Destroy all contexts
-   - Get the total number of watches on a context
+   - Emit internal events(eg. watches set, file info) for analytics
    - Get the list of root watch paths
  - Option to terminate context thread when watch list becomes empty
  - Ability to modify callback function pointer
- - Replace glib hashtables with a native implementation?
 
 
 [fluffy.h]:     libfluffy/fluffy.h

--- a/src/fluffy_ctl.c
+++ b/src/fluffy_ctl.c
@@ -383,13 +383,13 @@ main(int argc, char *argv[])
 
 	out_file = stdout;
 	err_file = stderr;
-        GOptionContext *argctx;
-        GError *error_g = NULL;
+	GOptionContext *argctx;
+	GError *error_g = NULL;
 
-        argctx = g_option_context_new(option_context);
-        g_option_context_add_main_entries(argctx, main_entries_g, NULL);
-        g_option_context_set_description(argctx, context_description);
-        g_option_context_set_summary(argctx, context_summary);
+	argctx = g_option_context_new(option_context);
+	g_option_context_add_main_entries(argctx, main_entries_g, NULL);
+	g_option_context_set_description(argctx, context_description);
+	g_option_context_set_summary(argctx, context_summary);
 
 	/* For event groups options */
 	gboolean event_all = FALSE;
@@ -516,7 +516,7 @@ main(int argc, char *argv[])
 		{ NULL }
 	};
 
-        GOptionGroup *group_g;
+	GOptionGroup *group_g;
 	gchar event_group_name[] = "events";
 	gchar event_group_description[] = ""
 		"When an option or more from 'events' group is passed, only "
@@ -530,7 +530,7 @@ main(int argc, char *argv[])
 			NULL,
 			NULL);
 	g_option_group_add_entries(group_g, event_entries_g);
-        g_option_context_add_group(argctx, group_g);
+	g_option_context_add_group(argctx, group_g);
 
 	if (argc < 2) {
 		/*
@@ -542,35 +542,35 @@ main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 
-        if (!g_option_context_parse(argctx, &argc, &argv, &error_g)) {
-                PRINT_STDERR("Failed parsing arguments: %s\n",
+	if (!g_option_context_parse(argctx, &argc, &argv, &error_g)) {
+		PRINT_STDERR("Failed parsing arguments: %s\n",
 				error_g->message);
-                exit(EXIT_FAILURE);
-        }
+		exit(EXIT_FAILURE);
+	}
 
 	/*
-        if (print_out != NULL) {
-                out_file = freopen(print_out, "we", stdout);
-                if (out_file == NULL) {
+	if (print_out != NULL) {
+		out_file = freopen(print_out, "we", stdout);
+		if (out_file == NULL) {
 			g_free(print_out);
 			print_out = NULL;
-                        perror("freopen");
-                        exit(EXIT_FAILURE);
-                }
+			perror("freopen");
+			exit(EXIT_FAILURE);
+		}
 		g_free(print_out);
 		print_out = NULL;
-        }
-        if (print_err != NULL) {
-                err_file = freopen(print_err, "we", stderr);
-                if (err_file == NULL) {
+	}
+	if (print_err != NULL) {
+		err_file = freopen(print_err, "we", stderr);
+		if (err_file == NULL) {
 			g_free(print_err);
 			print_err = NULL;
-                        perror("freopen");
-                        exit(EXIT_FAILURE);
-                }
+			perror("freopen");
+			exit(EXIT_FAILURE);
+		}
 		g_free(print_err);
 		print_err = NULL;
-        }
+	}
 	*/
 	stdin = freopen("/dev/null", "re", stdin);
 

--- a/src/fluffy_ctl.c
+++ b/src/fluffy_ctl.c
@@ -310,8 +310,10 @@ main(int argc, char *argv[])
 		"--help-events will show the options to modify this behaviour";
 
 	/* For main group options */
+	/*
 	gchar *print_out = NULL;
 	gchar *print_err = NULL;
+	*/
 	gchar **watch_paths = NULL;
 	gchar **ignore_paths = NULL;
 	gchar *max_user_watches = NULL;
@@ -323,6 +325,7 @@ main(int argc, char *argv[])
 	gboolean get_watch_nos = FALSE;
 
 	GOptionEntry main_entries_g[]= {
+		/*
 		{ "outfile", 'O', 0, G_OPTION_ARG_FILENAME,
 			&print_out,
 			"File to print output [default:stdout]",
@@ -331,6 +334,7 @@ main(int argc, char *argv[])
 			&print_err,
 			"File to print errors [default:stderr]",
 			"./err.fluffy" },
+		*/
 		{ "watch", 'w', 0, G_OPTION_ARG_FILENAME_ARRAY,
 			&watch_paths,
 			"Paths to watch recursively. Repeat flag for " \
@@ -544,6 +548,7 @@ main(int argc, char *argv[])
                 exit(EXIT_FAILURE);
         }
 
+	/*
         if (print_out != NULL) {
                 out_file = freopen(print_out, "we", stdout);
                 if (out_file == NULL) {
@@ -566,6 +571,7 @@ main(int argc, char *argv[])
 		g_free(print_err);
 		print_err = NULL;
         }
+	*/
 	stdin = freopen("/dev/null", "re", stdin);
 
 	do {

--- a/src/fluffy_run.c
+++ b/src/fluffy_run.c
@@ -424,51 +424,51 @@ main(int argc, char *argv[])
 	int reterr = 0;
 	out_file = stdout;
 	err_file = stderr;
-        GOptionContext *argctx;
-        GError *error_g = NULL;
+	GOptionContext *argctx;
+	GError *error_g = NULL;
 
-        argctx = g_option_context_new(option_context);
-        g_option_context_add_main_entries(argctx, entries_g, NULL);
-        g_option_context_set_description(argctx, context_description);
-        if (!g_option_context_parse(argctx, &argc, &argv, &error_g)) {
-                PRINT_STDERR("Failed parsing arguments: %s\n",
+	argctx = g_option_context_new(option_context);
+	g_option_context_add_main_entries(argctx, entries_g, NULL);
+	g_option_context_set_description(argctx, context_description);
+	if (!g_option_context_parse(argctx, &argc, &argv, &error_g)) {
+		PRINT_STDERR("Failed parsing arguments: %s\n",
 				error_g->message);
-                exit(EXIT_FAILURE);
-        }
+		exit(EXIT_FAILURE);
+	}
 
-        if (print_out != NULL) {
-                out_file = freopen(print_out, "we", stdout);
-                if (out_file == NULL) {
-                        perror("freopen");
-                        exit(EXIT_FAILURE);
-                }
+	if (print_out != NULL) {
+		out_file = freopen(print_out, "we", stdout);
+		if (out_file == NULL) {
+			perror("freopen");
+			exit(EXIT_FAILURE);
+		}
 
 		event_log = realpath(print_out, NULL);
 		if (event_log == NULL) {
 			perror("realpath");
-                        exit(EXIT_FAILURE);
+			exit(EXIT_FAILURE);
 		}
 
 		g_free(print_out);
 		print_out = NULL;
-        }
+	}
 
-        if (print_err != NULL) {
-                err_file = freopen(print_err, "we", stderr);
-                if (err_file == NULL) {
-                        perror("freopen");
-                        exit(EXIT_FAILURE);
-                }
+	if (print_err != NULL) {
+		err_file = freopen(print_err, "we", stderr);
+		if (err_file == NULL) {
+			perror("freopen");
+			exit(EXIT_FAILURE);
+		}
 
 		error_log = realpath(print_err, NULL);
 		if (error_log == NULL) {
 			perror("realpath");
-                        exit(EXIT_FAILURE);
+			exit(EXIT_FAILURE);
 		}
 
 		g_free(print_err);
 		print_err = NULL;
-        }
+	}
 	stdin = freopen("/dev/null", "re", stdin);
 
 	if (argc > 1 && strcmp(argv[1], "exit") == 0) {


### PR DESCRIPTION
This must be done to prevent an event feedback loop.

Addresses #11 